### PR TITLE
Add explicit dependency on language-groovy

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "engines": {
     "atom": ">0.50.0"
   },
+  "dependencies": {
+    "language-groovy": "^0.7.0"
+  },
   "bugs": {
     "url": "https://github.com/skyisle/language-gradle/issues"
   }


### PR DESCRIPTION
Since the README mentions a hard dependency on `language-groovy`, we might as well make it explicit and automatic in the packaging metadata.